### PR TITLE
Go-like errors, fix Read()/Write(), improve docs

### DIFF
--- a/gfapi/doc.go
+++ b/gfapi/doc.go
@@ -2,4 +2,4 @@
 // used to access files/directories on a Gluster volume.
 // The design tries to follow the default go file handling functions provided
 // by the os package as much as possible.
-package gfapi //import "github.com/gluster/gogfapi/gfapi"
+package gfapi

--- a/gfapi/gfapi_test.go
+++ b/gfapi/gfapi_test.go
@@ -24,23 +24,23 @@ func TestInit(t *testing.T) {
 		t.Fatalf("Failed to allocate variable")
 	}
 
-	ret := vol.Init("localhost", "test")
-	if ret != 0 {
-		t.Fatalf("Failed to initialize volume. Ret = %d", ret)
+	err := vol.Init("localhost", "test")
+	if err != nil {
+		t.Fatalf("Failed to initialize volume. error: %v", err)
 	}
 }
 
 func TestSetLogging(t *testing.T) {
-	ret, err := vol.SetLogging("/var/log/glusterfs/test.log", LogDebug)
-	if ret != 0 && err != nil {
-		t.Fatalf("Unable to set Logging ret = %d; error = %v", ret, err)
+	err := vol.SetLogging("/var/log/glusterfs/test.log", LogDebug)
+	if err != nil {
+		t.Fatalf("Unable to set Logging: error:  %v", err)
 	}
 }
 
 func TestMount(t *testing.T) {
-	ret := vol.Mount()
-	if ret != 0 {
-		t.Fatalf("Failed to mount volume. Ret = %d", ret)
+	err := vol.Mount()
+	if err != nil {
+		t.Fatalf("Failed to mount volume. error: %v", err)
 	}
 }
 
@@ -249,8 +249,8 @@ func TestStatvfs(t *testing.T) {
 }
 
 func TestUnmount(t *testing.T) {
-	ret := vol.Unmount()
-	if ret != 0 {
-		t.Logf("Failed to unmount volume. Ret = %d", ret)
+	err := vol.Unmount()
+	if err != nil {
+		t.Logf("Failed to unmount volume. Ret = %v", err)
 	}
 }


### PR DESCRIPTION
* Init now returns error and accepts multiple volservers
* SetLogging, Unmount, Mount now return error
* Various functions were not checking the return value before returning
error. Cgo collects errno as the functions error return value.
* Read() and Write(), which implements io.Reader/io.Writer now operates on
the entire contents of the file. This is useful for passing a gluster
file as an io.Reader/io.Writer to tools like io.Copy.

Original PR: https://github.com/apcera/gogfapi-old/pull/1