### PR TITLE
Add travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+
+go:
+  - 1.11.x
+  - 1.10.x
+
+go_import_path: github.com/gluster/gogfapi
+
+dist: xenial
+addons:
+  apt:
+    update: true
+    packages:
+      - glusterfs-common
+
+services:
+  - docker
+
+before_script:
+  - bash -x test_setup.sh
+
+script:
+  - go test -v ./...

--- a/gfapi/gfapi_test.go
+++ b/gfapi/gfapi_test.go
@@ -33,7 +33,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestSetLogging(t *testing.T) {
-	err := vol.SetLogging("/var/log/glusterfs/test.log", LogDebug)
+	err := vol.SetLogging("./test.log", LogDebug)
 	if err != nil {
 		t.Fatalf("Unable to set Logging: error:  %v", err)
 	}

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+docker run -d --name gluster-test \
+  -p 24007:24007/tcp -p 24008:24008/tcp -p 24007:24007/udp -p 24008:24008/udp \
+  -p 49152:49152/tcp -p 49152:49152/udp -p 49153:49153/tcp -p 49154:49154/tcp \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged=true \
+  gluster/gluster-centos:gluster4u0_centos7
+
+# wait for glusterd service to be active
+while ! docker exec gluster-test systemctl is-active glusterd; do
+  sleep 1
+done
+
+docker exec gluster-test /bin/sh -c "echo '127.0.1.1 $(hostname)' >> /etc/hosts"
+docker exec gluster-test gluster volume create test $(hostname):/srv force
+docker exec gluster-test gluster volume set test storage.owner-uid $(id -u)
+docker exec gluster-test gluster volume start test


### PR DESCRIPTION
It depends on #26. I can rebase the PR after it is merged.

It is based on [go-billy-gluster](https://github.com/src-d/go-billy-gluster) testing. The bulk of work is done in `test_setup.sh`:

* Start a docker container with gluster server from https://hub.docker.com/r/gluster/gluster-centos/
* Redirect needed ports to localhost
* Adds the hostname of the machine to the container so the client can resolve the name
* Creates a `test` volume with needed permissions

I've also changed the place of the testing logs so `root` permissions are not needed.

Adding the repository to a travis account should be enough. No other configuration is needed. You can check a test run from my travis account:

https://github.com/jfontan/gogfapi/runs/39555086